### PR TITLE
Support for Lua 5.3: If the bit library does not exist, use native operations

### DIFF
--- a/amqp.lua
+++ b/amqp.lua
@@ -8,12 +8,26 @@ local c = require "consts"
 local frame = require "frame"
 local logger = require "logger"
 
-local bit = require "bit"
-local band = bit.band
-local bor = bit.bor
-local lshift = bit.lshift
-local rshift = bit.rshift
-local tohex = bit.tohex
+-- Try to load bit library
+local bit
+local have_bit = pcall(function() bit = require "bit" end)
+
+-- If we have the bit library, use that, otherwise, use built-in operators
+-- (which are only available in Lua 5.3)
+local band, bor, lshift, rshift, tohex
+if have_bit then
+  band = bit.band
+  bor = bit.bor
+  lshift = bit.lshift
+  rshift = bit.rshift
+  tohex = bit.tohex
+else
+  band = function(a,b) return a & b end
+  bor = function(a,b) return a | b end
+  lshift = function(a,b) return a << b end
+  rshift = function(a,b) return a >> b end
+  tohex = function(a) return string.format("%x", a) end
+end
 
 local format = string.format
 local gmatch = string.gmatch

--- a/bitopers.lua
+++ b/bitopers.lua
@@ -1,0 +1,27 @@
+
+module("bitops",package.seeall)
+
+-- Try to load bit library
+local bit
+local have_bit = pcall(function() bit = require "bit" end)
+
+-- If we have the bit library, use that, otherwise, use built-in operators
+-- (which are only available in Lua 5.3)
+if have_bit then
+  return {
+    band = bit.band,
+    bor = bit.bor,
+    lshift = bit.lshift,
+    rshift = bit.rshift,
+    tohex = bit.tohex
+  }
+else
+  return {
+    band = function(a,b) return a & b end,
+    bor = function(a,b) return a | b end,
+    lshift = function(a,b) return a << b end,
+    rshift = function(a,b) return a >> b end,
+    tohex = function(a) return string.format("%x", a) end
+  }
+end
+

--- a/frame.lua
+++ b/frame.lua
@@ -12,9 +12,20 @@ local c = require "consts"
 local buffer = require "buffer"
 local logger = require "logger"
 
-local bit = require "bit"
-local band = bit.band
-local bor = bit.bor
+-- Try to load bit library
+local bit
+local have_bit = pcall(function() bit = require "bit" end)
+
+-- If we have the bit library, use that, otherwise, use built-in operators
+-- (which are only available in Lua 5.3)
+local band, bor
+if have_bit then
+  band = bit.band
+  bor = bit.bor
+else
+  band = function(a,b) return a & b end
+  bor = function(a,b) return a | b end
+end
 
 local byte = string.byte
 local format = string.format


### PR DESCRIPTION
This change adds support for Lua 5.3 native bit operations.  If the bit library does not exist (you wouldn't install on 5.3), use native Lua 5.3 bit operations.
