### PR TITLE
Support large messages by splitting into multiple content body

### DIFF
--- a/amqp.lua
+++ b/amqp.lua
@@ -633,14 +633,33 @@ function amqp:publish(payload)
       logger.error("[amqp.publish] failed: " .. err)
       return nil, err
    end
-   
-   local ok, err = frame.wire_body_frame(self,payload)
-   if not ok then
-      logger.error("[amqp.publish] failed: " .. err)
-      return nil, err
+
+   local max = self.frame_max
+
+   local pos = 0
+   local left = size
+
+   while left > 0 do
+
+      if left < max then
+         chunk = left
+      else
+         chunk = max
+      end
+
+      local ok, err = frame.wire_body_frame(self, payload, pos + 1, pos + chunk)
+      if not ok then
+         logger.error("[amqp.publish] failed: " .. err)
+         return nil, err
+      end
+
+      pos = pos + chunk
+      left = left - chunk
+
    end
-   
+
    return true
+
 end
 
 --

--- a/frame.lua
+++ b/frame.lua
@@ -1304,9 +1304,9 @@ function _M.wire_header_frame(ctx,body_size)
    return bytes
 end
 
-function _M.wire_body_frame(ctx,payload)
+function _M.wire_body_frame(ctx,payload, s, e)
    local frame = _M.new(c.frame.BODY_FRAME,ctx.opts.channel or 1)
-   frame.body = payload
+   frame.body = payload:sub(s, e)
    local msg = frame:encode()
    local sock = ctx.sock
    local bytes, err = sock:send(msg)


### PR DESCRIPTION
This submits content messages as multiple frames to deal with the case that a message exceeds the frame-max value.  See #3.